### PR TITLE
Get away from master-slave words

### DIFF
--- a/elector.go
+++ b/elector.go
@@ -49,7 +49,7 @@ type WriteOptions struct {
 	KeepAlive bool
 }
 
-// Elector use set-watch mechanism to realize master-slave election
+// Elector use set-watch mechanism to realize main-subordinate election
 type Elector interface {
 	// Watch watch what happens to key
 	Watch(ctx context.Context, key string, stopCh <-chan struct{}) (<-chan *WatchRes, error)


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.